### PR TITLE
Update tax_rate.rb

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -87,7 +87,7 @@ module Spree
       tax_categories = rates.map(&:tax_category)
       relevant_items, non_relevant_items = items.partition { |item| tax_categories.include?(item.tax_category) }
       unless relevant_items.empty?
-        Spree::Adjustment.where(adjustable: relevant_items).tax.destroy_all # using destroy_all to ensure adjustment destroy callback fires.
+        relevant_items.map(&:adjustments).map(&:tax).map(&:destroy_all) # using destroy_all to ensure adjustment destroy callback fires.
       end
       relevant_items.each do |item|
         relevant_rates = rates.select { |rate| rate.tax_category == item.tax_category }


### PR DESCRIPTION
Fix bug where if relevant_items array contained more than one class type, it would only return adjustments for 1 class type.
